### PR TITLE
fix: Fixed UI Patch for addChild operation

### DIFF
--- a/lib/lenra_ui_builder.dart
+++ b/lib/lenra_ui_builder.dart
@@ -201,7 +201,7 @@ class LenraUiBuilderState extends State<LenraUiBuilder> {
     if (patch.childId == null) return;
 
     registerComponent(patch.value as Map<String, dynamic>, patch.childId!);
-    if (patch.childIndex == null) {
+    if (patch.childIndex == null || int.tryParse(patch.childIndex!) == null) {
       properties[patch.propertyPathList.first] = patch.childId;
     } else {
       if (patch.childIndex == '-') {

--- a/test/lenra_ui_builder_test.dart
+++ b/test/lenra_ui_builder_test.dart
@@ -140,4 +140,51 @@ void main() {
     expect(find.text("foo"), findsNothing);
     expect(find.text("bar"), findsOneWidget);
   });
+
+  testWidgets('Change child of styledContainer', (WidgetTester tester) async {
+    StreamController<Map<String, dynamic>> uiStream = StreamController();
+    StreamController<List<Map<String, dynamic>>> patchUiStream = StreamController();
+
+    await tester.pumpWidget(
+      createBaseTestWidgets(
+        child: LenraUiBuilder(uiStream: uiStream, patchUiStream: patchUiStream),
+      ),
+    );
+
+    Map<String, dynamic> ui = {
+      "root": {
+        "type": "button",
+        "text": "foo",
+        "onPressed": {"code": "john"}
+      }
+    };
+
+    List<Map<String, dynamic>> patches = [
+      {"op": "remove", "path": "/root/onPressed"},
+      {"op": "remove", "path": "/root/text"},
+      {"op": "replace", "path": "/root/type", "value": "styledContainer"},
+      {
+        "op": "add",
+        "path": "/root/child",
+        "value": {
+          "type": "button",
+          "text": "bar",
+          "onPressed": {"code": "doe"}
+        }
+      }
+    ];
+
+    uiStream.add(ui);
+    await tester.pump();
+
+    expect(find.text("foo"), findsOneWidget);
+    expect(find.text("bar"), findsNothing);
+
+    patchUiStream.add(patches);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text("bar"), findsOneWidget);
+    expect(find.text("foo"), findsNothing);
+  });
 }


### PR DESCRIPTION
The problem was that when adding a new child to the properties, it was considered as part of a `children` property, which means it was trying to add a new child to the `children` at index `child`. 
Adding a new condition at this line https://github.com/lenra-io/lenra_ui_runner/pull/55/files#diff-d375fcc6f8eb985b59f7f4adc1b639b9a21997737643b7e58bbf106ac5f4e3bcR204 (L.204) seems to fix this issue because the `childIndex` can be either `null` or the name of the child.