### PR TITLE
feat: Add error snackbar & error page on App errors

### DIFF
--- a/examples/showcase/lib/ui_builder.dart
+++ b/examples/showcase/lib/ui_builder.dart
@@ -38,7 +38,12 @@ abstract class UiBuilderState<T extends StatefulWidget, D> extends State<T> {
   Widget build(BuildContext context) {
     return NotificationListener<Event>(
       onNotification: (Event event) => handleNotifications(event),
-      child: LenraWidget(),
+      child: LenraWidget(
+        buildErrorPage: (_context, _error) {
+          return Text("Error");
+        },
+        showSnackBar: (_context, _errors) {},
+      ),
     );
   }
 }

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -17,16 +17,24 @@ class LenraWidget extends StatelessWidget {
             duration: Duration(minutes: 2),
             backgroundColor: LenraColorThemeData.lenraCustomRed,
             content: LenraFlex(
+              spacing: 2,
               direction: Axis.horizontal,
               children: errors +
                   [
                     Spacer(),
-                    //Should consider using api route to notify dev
+                    //TODO: We should consider using api route to notify dev
                     LenraButton(
                       disabled: true,
                       type: LenraComponentType.secondary,
                       onPressed: () {},
                       text: "Contact developper",
+                    ),
+                    LenraButton(
+                      type: LenraComponentType.secondary,
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).clearSnackBars();
+                      },
+                      leftIcon: Icon(Icons.close),
                     )
                   ],
             ),

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -25,9 +25,9 @@ import 'package:lenra_ui_runner/components/lenra_flex.dart';
 import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class LenraWidget extends StatelessWidget {
-  static List<Widget> _errors = [];
   static Function appErrorUI = () {};
   static Function appErrorCallback = () {};
+  static List<Widget> _errors = [];
 
   @override
   Widget build(BuildContext context) {

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -8,9 +8,9 @@ class LenraWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     WidgetModel widgetModel = context.watch<WidgetModel>();
     Map<String, dynamic> ui = widgetModel.ui;
-    List<Widget> errors = widgetModel.errors;
+    bool error = widgetModel.error;
 
-    if (errors.isNotEmpty) {
+    if (error) {
       WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -19,7 +19,7 @@ class LenraWidget extends StatelessWidget {
             content: LenraFlex(
               spacing: 2,
               direction: Axis.horizontal,
-              children: errors +
+              children: widgetModel.errors +
                   [
                     Spacer(),
                     //TODO: We should consider using api route to notify dev

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lenra_components/component/lenra_button.dart';
 import 'package:lenra_components/layout/lenra_flex.dart';
+import 'package:lenra_components/lenra_components.dart';
+import 'package:lenra_components/theme/lenra_color_theme_data.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
 
@@ -10,49 +12,50 @@ class LenraWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     WidgetModel widgetModel = context.watch<WidgetModel>();
     Map<String, dynamic> ui = widgetModel.ui;
-    List<dynamic> errors = widgetModel.errors;
+    List<Widget> errors = widgetModel.errors;
 
     if (errors.isNotEmpty) {
-      if (widgetModel.ui == {}) {
-      } else {
-        // if (errors.length > 1) {
-        //   ScaffoldMessenger.of(context).showSnackBar(
-        //     SnackBar(
-        //       content: LenraFlex(
-        //         direction: Axis.horizontal,
-        //         children: [
-        //           Text("Many errors occurs please contact developper"),
-        //           Spacer(),
-        //           LenraButton(
-        //             onPressed: () {},
-        //             text: "Contact developper",
-        //           )
-        //         ],
-        //       ),
-        //     ),
-        //   );
-        // } else {
-        WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              duration: Duration(minutes: 5),
-              content: LenraFlex(
-                direction: Axis.horizontal,
-                children: [
-                  Text("Error: " + errors[0]["message"] + " Code: " + errors[0]["code"].toString()),
-                  Spacer(),
-                  LenraButton(
-                    onPressed: () {},
-                    text: "Contact developper",
-                  )
-                ],
-              ),
+      // if (errors.length > 1) {
+      //   ScaffoldMessenger.of(context).showSnackBar(
+      //     SnackBar(
+      //       content: LenraFlex(
+      //         direction: Axis.horizontal,
+      //         children: [
+      //           Text("Many errors occurs please contact developper"),
+      //           Spacer(),
+      //           LenraButton(
+      //             onPressed: () {},
+      //             text: "Contact developper",
+      //           )
+      //         ],
+      //       ),
+      //     ),
+      //   );
+      // } else {
+      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            duration: Duration(minutes: 2),
+            backgroundColor: LenraColorThemeData.lenraCustomRed,
+            content: LenraFlex(
+              direction: Axis.horizontal,
+              children: errors +
+                  [
+                    Spacer(),
+                    LenraButton(
+                      disabled: true,
+                      type: LenraComponentType.secondary,
+                      onPressed: () {},
+                      text: "Contact developper",
+                    )
+                  ],
             ),
-          );
-        });
+          ),
+        );
+      });
 
-        // }
-      }
+      // }
+
     }
 
     if (ui.keys.contains("root") && ui.keys.length == 1) {

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -4,30 +4,27 @@ import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
 import 'package:lenra_ui_runner/props_parser.dart';
 
-class LenraWidget extends StatelessWidget {
-  static Function? appErrorUI;
-  static Function? appErrorCallback;
-  static List<Widget>? _errors;
+class LenraWidget<E> extends StatelessWidget {
+  final Widget Function(BuildContext, E) buildErrorPage;
+  final Function(BuildContext, E) showSnackBar;
+
+  LenraWidget({required this.buildErrorPage, required this.showSnackBar});
 
   @override
   Widget build(BuildContext context) {
-    Map<String, dynamic> ui = context.select<WidgetModel, Map<String, dynamic>>((model) => model.ui);
-
-    bool error = context.select<WidgetModel, bool>((model) => model.error);
-
-    if (error) {
-      Map<dynamic, dynamic>? errors = context.select<WidgetModel, Map<dynamic, dynamic>?>((model) => model.errors);
-      for (var error in errors!["errors"]) {
-        LenraWidget._errors = [];
-        LenraWidget._errors!.add(Text("Error code: " + error["code"].toString()));
-        LenraWidget._errors!.add(Text(
-          "Message: " + error["message"],
-          textAlign: TextAlign.center,
-        ));
-      }
-      appErrorCallback!(context, error);
+    WidgetModel<E> widgetModel = context.watch<WidgetModel>() as WidgetModel<E>;
+    if (widgetModel.hasError() && !widgetModel.hasUi()) return buildErrorPage(context, widgetModel.errors!);
+    if (widgetModel.hasError()) {
+      WidgetsBinding.instance?.addPostFrameCallback((_) {
+        showSnackBar(context, widgetModel.errors!);
+      });
     }
 
+    if (!widgetModel.hasUi()) {
+      return CircularProgressIndicator();
+    }
+
+    Map<String, dynamic> ui = widgetModel.ui;
     if (ui.keys.contains("root") && ui.keys.length == 1) {
       return LenraWidget.parseJson(ui["root"]);
     }
@@ -36,8 +33,6 @@ class LenraWidget extends StatelessWidget {
   }
 
   static Widget parseJson(Map<String, dynamic> json) {
-    if (json.isEmpty) return LenraWidget.appErrorUI != null ? appErrorUI!(_errors) : Text("Unknow error");
-
     String? type = Parser.getType(json);
     if (type == null) {
       throw "No type in component. It should never happen";

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:lenra_components/lenra_components.dart';
 import 'package:lenra_ui_runner/lenra_component_builder.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
@@ -26,8 +25,8 @@ import 'package:lenra_ui_runner/components/lenra_flex.dart';
 import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class LenraWidget extends StatelessWidget {
-  static Function appErrorUI = () {};
   static List<Widget> _errors = [];
+  static Function appErrorUI = () {};
   static Function appErrorCallback = () {};
 
   @override

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -25,8 +25,8 @@ import 'package:lenra_ui_runner/components/lenra_flex.dart';
 import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class LenraWidget extends StatelessWidget {
-  static late Function appErrorUI;
-  static late Function appErrorCallback;
+  static Function? appErrorUI;
+  static Function? appErrorCallback;
   static List<Widget> _errors = [];
 
   @override
@@ -38,7 +38,7 @@ class LenraWidget extends StatelessWidget {
     if (error) {
       List<Widget> error = context.select<WidgetModel, List<Widget>>((model) => model.errors);
       LenraWidget._errors = error;
-      appErrorCallback(context, error);
+      appErrorCallback!(context, error);
     }
 
     if (ui.keys.contains("root") && ui.keys.length == 1) {
@@ -72,7 +72,7 @@ class LenraWidget extends StatelessWidget {
   };
 
   static Widget parseJson(Map<String, dynamic> json) {
-    if (json.isEmpty) return appErrorUI(_errors);
+    if (json.isEmpty) return appErrorUI != null ? appErrorUI!(_errors) : Container();
 
     String? type = getType(json);
     if (type == null) {

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -72,7 +72,7 @@ class LenraWidget extends StatelessWidget {
   };
 
   static Widget parseJson(Map<String, dynamic> json) {
-    if (json.isEmpty) return appErrorUI != null ? appErrorUI!(_errors) : Container();
+    if (json.isEmpty) return appErrorUI != null ? appErrorUI!(_errors) : Text("Unknow error");
 
     String? type = getType(json);
     if (type == null) {

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -2,32 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:lenra_ui_runner/lenra_component_builder.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
-import 'package:lenra_ui_runner/components/lenra_button.dart';
-import 'package:lenra_ui_runner/components/lenra_checkbox.dart';
-import 'package:lenra_ui_runner/components/lenra_icon.dart';
-import 'package:lenra_ui_runner/components/lenra_image.dart';
-import 'package:lenra_ui_runner/components/lenra_overlay_entry.dart';
-import 'package:lenra_ui_runner/components/lenra_radio.dart';
-import 'package:lenra_ui_runner/components/lenra_text.dart';
-import 'package:lenra_ui_runner/components/lenra_textfield.dart';
 import 'package:lenra_ui_runner/props_parser.dart';
-import 'package:lenra_ui_runner/components/lenra_dropdown_button.dart';
-import 'package:lenra_ui_runner/components/lenra_flexible.dart';
-import 'package:lenra_ui_runner/components/lenra_container.dart';
-import 'package:lenra_ui_runner/components/lenra_stack.dart';
-import 'package:lenra_ui_runner/components/lenra_slider.dart';
-import 'package:lenra_ui_runner/components/lenra_actionable.dart';
-import 'package:lenra_ui_runner/components/lenra_menu.dart';
-import 'package:lenra_ui_runner/components/lenra_menu_item.dart';
-import 'package:lenra_ui_runner/components/lenra_toggle.dart';
-import 'package:lenra_ui_runner/components/lenra_status_sticker.dart';
-import 'package:lenra_ui_runner/components/lenra_flex.dart';
-import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class LenraWidget extends StatelessWidget {
   static Function? appErrorUI;
   static Function? appErrorCallback;
-  static List<Widget> _errors = [];
+  static List<Widget>? _errors;
 
   @override
   Widget build(BuildContext context) {
@@ -36,8 +16,15 @@ class LenraWidget extends StatelessWidget {
     bool error = context.select<WidgetModel, bool>((model) => model.error);
 
     if (error) {
-      List<Widget> error = context.select<WidgetModel, List<Widget>>((model) => model.errors);
-      LenraWidget._errors = error;
+      Map<dynamic, dynamic>? errors = context.select<WidgetModel, Map<dynamic, dynamic>?>((model) => model.errors);
+      for (var error in errors!["errors"]) {
+        LenraWidget._errors = [];
+        LenraWidget._errors!.add(Text("Error code: " + error["code"].toString()));
+        LenraWidget._errors!.add(Text(
+          "Message: " + error["message"],
+          textAlign: TextAlign.center,
+        ));
+      }
       appErrorCallback!(context, error);
     }
 
@@ -48,70 +35,16 @@ class LenraWidget extends StatelessWidget {
     return LenraWidget.parseJson(ui);
   }
 
-  static final Map<String, LenraComponentBuilder> componentsMapping = {
-    'text': LenraTextBuilder(),
-    'textfield': LenraTextfieldBuilder(),
-    'button': LenraButtonBuilder(),
-    'checkbox': LenraCheckboxBuilder(),
-    'image': LenraImageBuilder(),
-    'radio': LenraRadioBuilder(),
-    'menu': LenraMenuBuilder(),
-    'menuItem': LenraMenuItemBuilder(),
-    'toggle': LenraToggleBuilder(),
-    'statusSticker': LenraStatusStickerBuilder(),
-    'flex': LenraFlexBuilder(),
-    'container': LenraContainerBuilder(),
-    'actionable': LenraActionableBuilder(),
-    'dropdownButton': LenraDropdownButtonBuilder(),
-    'flexible': LenraFlexibleBuilder(),
-    'wrap': LenraWrapBuilder(),
-    'stack': LenraStackBuilder(),
-    'slider': LenraSliderBuilder(),
-    'overlayEntry': LenraOverlayEntryBuilder(),
-    'icon': LenraIconBuilder(),
-  };
-
   static Widget parseJson(Map<String, dynamic> json) {
-    if (json.isEmpty) return appErrorUI != null ? appErrorUI!(_errors) : Text("Unknow error");
+    if (json.isEmpty) return LenraWidget.appErrorUI != null ? appErrorUI!(_errors) : Text("Unknow error");
 
-    String? type = getType(json);
+    String? type = Parser.getType(json);
     if (type == null) {
       throw "No type in component. It should never happen";
     }
-    LenraComponentBuilder? builder = getComponentBuilder(type);
+    LenraComponentBuilder? builder = Parser.getComponentBuilder(type);
     if (builder == null) throw "Componnent mapping does not handle type $type";
-    Map<Symbol, dynamic> parsedProps = parseProps(json, builder.propsTypes);
+    Map<Symbol, dynamic> parsedProps = Parser.parseProps(json, builder.propsTypes);
     return builder.build(parsedProps);
-  }
-
-  static String? getType(Map<String, dynamic> json) {
-    return json['type'] as String?;
-  }
-
-  static LenraComponentBuilder? getComponentBuilder(String type) {
-    if (componentsMapping.containsKey(type)) {
-      return componentsMapping[type];
-    }
-
-    return null;
-  }
-
-  static Map<Symbol, dynamic> parseProps(Map<String, dynamic> json, Map<String, Type> propsTypes) {
-    Map<Symbol, dynamic> transformedProps = {};
-
-    json.forEach((key, value) {
-      if (propsTypes.containsKey(key)) {
-        Function? parser = getParser(propsTypes[key]!);
-        if (parser != null) {
-          transformedProps[Symbol(key)] = parser(value);
-        }
-      }
-    });
-
-    return transformedProps;
-  }
-
-  static Function? getParser(Type t) {
-    return ParserExt.typeParsers[t];
   }
 }

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -25,8 +25,8 @@ import 'package:lenra_ui_runner/components/lenra_flex.dart';
 import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class LenraWidget extends StatelessWidget {
-  static Function appErrorUI = () {};
-  static Function appErrorCallback = () {};
+  static late Function appErrorUI;
+  static late Function appErrorCallback;
   static List<Widget> _errors = [];
 
   @override

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:lenra_components/component/lenra_button.dart';
+import 'package:lenra_components/layout/lenra_flex.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
 
@@ -7,6 +10,50 @@ class LenraWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     WidgetModel widgetModel = context.watch<WidgetModel>();
     Map<String, dynamic> ui = widgetModel.ui;
+    List<dynamic> errors = widgetModel.errors;
+
+    if (errors.isNotEmpty) {
+      if (widgetModel.ui == {}) {
+      } else {
+        // if (errors.length > 1) {
+        //   ScaffoldMessenger.of(context).showSnackBar(
+        //     SnackBar(
+        //       content: LenraFlex(
+        //         direction: Axis.horizontal,
+        //         children: [
+        //           Text("Many errors occurs please contact developper"),
+        //           Spacer(),
+        //           LenraButton(
+        //             onPressed: () {},
+        //             text: "Contact developper",
+        //           )
+        //         ],
+        //       ),
+        //     ),
+        //   );
+        // } else {
+        WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              duration: Duration(minutes: 5),
+              content: LenraFlex(
+                direction: Axis.horizontal,
+                children: [
+                  Text("Error: " + errors[0]["message"] + " Code: " + errors[0]["code"].toString()),
+                  Spacer(),
+                  LenraButton(
+                    onPressed: () {},
+                    text: "Contact developper",
+                  )
+                ],
+              ),
+            ),
+          );
+        });
+
+        // }
+      }
+    }
 
     if (ui.keys.contains("root") && ui.keys.length == 1) {
       return WidgetModel.parseJson(ui["root"]);

--- a/lib/lenra_widget.dart
+++ b/lib/lenra_widget.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
-import 'package:lenra_components/component/lenra_button.dart';
-import 'package:lenra_components/layout/lenra_flex.dart';
 import 'package:lenra_components/lenra_components.dart';
-import 'package:lenra_components/theme/lenra_color_theme_data.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
 
@@ -15,23 +11,6 @@ class LenraWidget extends StatelessWidget {
     List<Widget> errors = widgetModel.errors;
 
     if (errors.isNotEmpty) {
-      // if (errors.length > 1) {
-      //   ScaffoldMessenger.of(context).showSnackBar(
-      //     SnackBar(
-      //       content: LenraFlex(
-      //         direction: Axis.horizontal,
-      //         children: [
-      //           Text("Many errors occurs please contact developper"),
-      //           Spacer(),
-      //           LenraButton(
-      //             onPressed: () {},
-      //             text: "Contact developper",
-      //           )
-      //         ],
-      //       ),
-      //     ),
-      //   );
-      // } else {
       WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -42,6 +21,7 @@ class LenraWidget extends StatelessWidget {
               children: errors +
                   [
                     Spacer(),
+                    //Should consider using api route to notify dev
                     LenraButton(
                       disabled: true,
                       type: LenraComponentType.secondary,
@@ -53,9 +33,6 @@ class LenraWidget extends StatelessWidget {
           ),
         );
       });
-
-      // }
-
     }
 
     if (ui.keys.contains("root") && ui.keys.length == 1) {

--- a/lib/props_parser.dart
+++ b/lib/props_parser.dart
@@ -8,7 +8,6 @@ import 'package:lenra_components/theme/lenra_theme_data.dart';
 import 'package:lenra_components/theme/lenra_toggle_style.dart';
 import 'package:lenra_ui_runner/components/listeners/listener.dart' as lenra;
 import 'package:lenra_ui_runner/lenra_widget.dart';
-import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:lenra_ui_runner/utils/icon_util.dart';
 import 'package:lenra_ui_runner/components/children_widgets.dart';
 

--- a/lib/props_parser.dart
+++ b/lib/props_parser.dart
@@ -10,6 +10,27 @@ import 'package:lenra_ui_runner/components/listeners/listener.dart' as lenra;
 import 'package:lenra_ui_runner/lenra_widget.dart';
 import 'package:lenra_ui_runner/utils/icon_util.dart';
 import 'package:lenra_ui_runner/components/children_widgets.dart';
+import 'package:lenra_ui_runner/components/lenra_button.dart';
+import 'package:lenra_ui_runner/lenra_component_builder.dart';
+import 'package:lenra_ui_runner/components/lenra_checkbox.dart';
+import 'package:lenra_ui_runner/components/lenra_icon.dart';
+import 'package:lenra_ui_runner/components/lenra_image.dart';
+import 'package:lenra_ui_runner/components/lenra_overlay_entry.dart';
+import 'package:lenra_ui_runner/components/lenra_radio.dart';
+import 'package:lenra_ui_runner/components/lenra_text.dart';
+import 'package:lenra_ui_runner/components/lenra_textfield.dart';
+import 'package:lenra_ui_runner/components/lenra_dropdown_button.dart';
+import 'package:lenra_ui_runner/components/lenra_flexible.dart';
+import 'package:lenra_ui_runner/components/lenra_container.dart';
+import 'package:lenra_ui_runner/components/lenra_stack.dart';
+import 'package:lenra_ui_runner/components/lenra_slider.dart';
+import 'package:lenra_ui_runner/components/lenra_actionable.dart';
+import 'package:lenra_ui_runner/components/lenra_menu.dart';
+import 'package:lenra_ui_runner/components/lenra_menu_item.dart';
+import 'package:lenra_ui_runner/components/lenra_toggle.dart';
+import 'package:lenra_ui_runner/components/lenra_status_sticker.dart';
+import 'package:lenra_ui_runner/components/lenra_flex.dart';
+import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 extension ParserExt on Parser {
   // TODO : Generate this from annotation on class Parser
@@ -60,6 +81,45 @@ extension ParserExt on Parser {
 }
 
 class Parser {
+  static final Map<String, LenraComponentBuilder> componentsMapping = {
+    'text': LenraTextBuilder(),
+    'textfield': LenraTextfieldBuilder(),
+    'button': LenraButtonBuilder(),
+    'checkbox': LenraCheckboxBuilder(),
+    'image': LenraImageBuilder(),
+    'radio': LenraRadioBuilder(),
+    'menu': LenraMenuBuilder(),
+    'menuItem': LenraMenuItemBuilder(),
+    'toggle': LenraToggleBuilder(),
+    'statusSticker': LenraStatusStickerBuilder(),
+    'flex': LenraFlexBuilder(),
+    'container': LenraContainerBuilder(),
+    'actionable': LenraActionableBuilder(),
+    'dropdownButton': LenraDropdownButtonBuilder(),
+    'flexible': LenraFlexibleBuilder(),
+    'wrap': LenraWrapBuilder(),
+    'stack': LenraStackBuilder(),
+    'slider': LenraSliderBuilder(),
+    'overlayEntry': LenraOverlayEntryBuilder(),
+    'icon': LenraIconBuilder(),
+  };
+
+  static String? getType(Map<String, dynamic> json) {
+    return json['type'] as String?;
+  }
+
+  static LenraComponentBuilder? getComponentBuilder(String type) {
+    if (componentsMapping.containsKey(type)) {
+      return componentsMapping[type];
+    }
+
+    return null;
+  }
+
+  static Function? getParser(Type t) {
+    return ParserExt.typeParsers[t];
+  }
+
   static lenra.Listener parseListener(Map<String, dynamic> listener) {
     return lenra.Listener(listener["code"]);
   }

--- a/lib/props_parser.dart
+++ b/lib/props_parser.dart
@@ -7,6 +7,7 @@ import 'package:lenra_components/theme/lenra_slider_style.dart';
 import 'package:lenra_components/theme/lenra_theme_data.dart';
 import 'package:lenra_components/theme/lenra_toggle_style.dart';
 import 'package:lenra_ui_runner/components/listeners/listener.dart' as lenra;
+import 'package:lenra_ui_runner/lenra_widget.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:lenra_ui_runner/utils/icon_util.dart';
 import 'package:lenra_ui_runner/components/children_widgets.dart';
@@ -596,7 +597,7 @@ class Parser {
   }
 
   static Widget parseWidget(Map<String, dynamic> props) {
-    return WidgetModel.parseJson(props);
+    return LenraWidget.parseJson(props);
   }
 
   static FilterQuality parseFilterQuality(String value) {

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -25,8 +25,11 @@ import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class WidgetModel extends ChangeNotifier {
   Map<String, dynamic> _ui = {};
+  List<dynamic> _errors = [];
 
   Map<String, dynamic> get ui => _ui;
+
+  List<dynamic> get errors => _errors;
 
   void replaceUi(Map<String, dynamic> ui) {
     _ui = ui;
@@ -35,6 +38,11 @@ class WidgetModel extends ChangeNotifier {
 
   void patchUi(Iterable<Map<String, dynamic>> patches) {
     replaceUi(JsonPatch.apply(_ui, patches, strict: false));
+  }
+
+  void AppErrors(Map<dynamic, dynamic>? response) {
+    _errors = response!["errors"];
+    notifyListeners();
   }
 
   static final Map<String, LenraComponentBuilder> componentsMapping = {

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -27,7 +27,7 @@ class WidgetModel extends ChangeNotifier {
   bool error = false;
   Map<String, dynamic> _ui = {};
   List<Widget> _errors = [];
-  static late Widget appErrorUI;
+  static Widget appErrorUI = Container();
 
   Map<String, dynamic> get ui => _ui;
 

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -1,14 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:json_patch/json_patch.dart';
 
-class WidgetModel extends ChangeNotifier {
-  bool error = false;
-  Map<String, dynamic> _ui = {};
-  Map<dynamic, dynamic>? _errors = <dynamic, dynamic>{};
+class WidgetModel<E> extends ChangeNotifier {
+  Map<String, dynamic>? _ui;
+  E? _errors;
 
-  Map<String, dynamic> get ui => _ui;
+  Map<String, dynamic> get ui => hasUi() ? _ui! : {};
+  E? get errors => _errors;
 
-  Map<dynamic, dynamic>? get errors => _errors;
+  bool hasError() {
+    return _errors != null;
+  }
+
+  bool hasUi() {
+    return _ui != null;
+  }
 
   void replaceUi(Map<String, dynamic> ui) {
     _ui = ui;
@@ -19,9 +25,8 @@ class WidgetModel extends ChangeNotifier {
     replaceUi(JsonPatch.apply(_ui, patches, strict: false));
   }
 
-  void appErrors(Map<dynamic, dynamic>? json) {
-    error = true;
-    _errors = json;
+  void setErrors(E errors) {
+    _errors = errors;
     notifyListeners();
   }
 }

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -24,8 +24,10 @@ import 'package:lenra_ui_runner/components/lenra_flex.dart';
 import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class WidgetModel extends ChangeNotifier {
+  bool error = false;
   Map<String, dynamic> _ui = {};
   List<Widget> _errors = [];
+  static late Widget appErrorUI;
 
   Map<String, dynamic> get ui => _ui;
 
@@ -41,6 +43,7 @@ class WidgetModel extends ChangeNotifier {
   }
 
   void appErrors(List<Widget> errors) {
+    error = true;
     _errors = errors;
     notifyListeners();
   }
@@ -69,7 +72,7 @@ class WidgetModel extends ChangeNotifier {
   };
 
   static Widget parseJson(Map<String, dynamic> json) {
-    if (json.isEmpty) return Text("No Components.");
+    if (json.isEmpty) return appErrorUI;
 
     String? type = getType(json);
     if (type == null) {

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -25,11 +25,11 @@ import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class WidgetModel extends ChangeNotifier {
   Map<String, dynamic> _ui = {};
-  List<dynamic> _errors = [];
+  List<Widget> _errors = [];
 
   Map<String, dynamic> get ui => _ui;
 
-  List<dynamic> get errors => _errors;
+  List<Widget> get errors => _errors;
 
   void replaceUi(Map<String, dynamic> ui) {
     _ui = ui;
@@ -40,8 +40,8 @@ class WidgetModel extends ChangeNotifier {
     replaceUi(JsonPatch.apply(_ui, patches, strict: false));
   }
 
-  void AppErrors(Map<dynamic, dynamic>? response) {
-    _errors = response!["errors"];
+  void appErrors(List<Widget> errors, Widget callback) {
+    _errors = errors;
     notifyListeners();
   }
 

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -40,7 +40,7 @@ class WidgetModel extends ChangeNotifier {
     replaceUi(JsonPatch.apply(_ui, patches, strict: false));
   }
 
-  void appErrors(List<Widget> errors, Widget callback) {
+  void appErrors(List<Widget> errors) {
     _errors = errors;
     notifyListeners();
   }

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -4,11 +4,11 @@ import 'package:json_patch/json_patch.dart';
 class WidgetModel extends ChangeNotifier {
   bool error = false;
   Map<String, dynamic> _ui = {};
-  List<Widget> _errors = [];
+  Map<dynamic, dynamic>? _errors = <dynamic, dynamic>{};
 
   Map<String, dynamic> get ui => _ui;
 
-  List<Widget> get errors => _errors;
+  Map<dynamic, dynamic>? get errors => _errors;
 
   void replaceUi(Map<String, dynamic> ui) {
     _ui = ui;
@@ -19,9 +19,9 @@ class WidgetModel extends ChangeNotifier {
     replaceUi(JsonPatch.apply(_ui, patches, strict: false));
   }
 
-  void appErrors(List<Widget> errors) {
+  void appErrors(Map<dynamic, dynamic>? json) {
     error = true;
-    _errors = errors;
+    _errors = json;
     notifyListeners();
   }
 }

--- a/lib/widget_model.dart
+++ b/lib/widget_model.dart
@@ -1,33 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:json_patch/json_patch.dart';
-import 'package:lenra_ui_runner/components/lenra_button.dart';
-import 'package:lenra_ui_runner/components/lenra_checkbox.dart';
-import 'package:lenra_ui_runner/components/lenra_icon.dart';
-import 'package:lenra_ui_runner/components/lenra_image.dart';
-import 'package:lenra_ui_runner/components/lenra_overlay_entry.dart';
-import 'package:lenra_ui_runner/components/lenra_radio.dart';
-import 'package:lenra_ui_runner/components/lenra_text.dart';
-import 'package:lenra_ui_runner/components/lenra_textfield.dart';
-import 'package:lenra_ui_runner/lenra_component_builder.dart';
-import 'package:lenra_ui_runner/props_parser.dart';
-import 'package:lenra_ui_runner/components/lenra_dropdown_button.dart';
-import 'package:lenra_ui_runner/components/lenra_flexible.dart';
-import 'package:lenra_ui_runner/components/lenra_container.dart';
-import 'package:lenra_ui_runner/components/lenra_stack.dart';
-import 'package:lenra_ui_runner/components/lenra_slider.dart';
-import 'package:lenra_ui_runner/components/lenra_actionable.dart';
-import 'package:lenra_ui_runner/components/lenra_menu.dart';
-import 'package:lenra_ui_runner/components/lenra_menu_item.dart';
-import 'package:lenra_ui_runner/components/lenra_toggle.dart';
-import 'package:lenra_ui_runner/components/lenra_status_sticker.dart';
-import 'package:lenra_ui_runner/components/lenra_flex.dart';
-import 'package:lenra_ui_runner/components/lenra_wrap.dart';
 
 class WidgetModel extends ChangeNotifier {
   bool error = false;
   Map<String, dynamic> _ui = {};
   List<Widget> _errors = [];
-  static Widget appErrorUI = Container();
 
   Map<String, dynamic> get ui => _ui;
 
@@ -46,72 +23,5 @@ class WidgetModel extends ChangeNotifier {
     error = true;
     _errors = errors;
     notifyListeners();
-  }
-
-  static final Map<String, LenraComponentBuilder> componentsMapping = {
-    'text': LenraTextBuilder(),
-    'textfield': LenraTextfieldBuilder(),
-    'button': LenraButtonBuilder(),
-    'checkbox': LenraCheckboxBuilder(),
-    'image': LenraImageBuilder(),
-    'radio': LenraRadioBuilder(),
-    'menu': LenraMenuBuilder(),
-    'menuItem': LenraMenuItemBuilder(),
-    'toggle': LenraToggleBuilder(),
-    'statusSticker': LenraStatusStickerBuilder(),
-    'flex': LenraFlexBuilder(),
-    'container': LenraContainerBuilder(),
-    'actionable': LenraActionableBuilder(),
-    'dropdownButton': LenraDropdownButtonBuilder(),
-    'flexible': LenraFlexibleBuilder(),
-    'wrap': LenraWrapBuilder(),
-    'stack': LenraStackBuilder(),
-    'slider': LenraSliderBuilder(),
-    'overlayEntry': LenraOverlayEntryBuilder(),
-    'icon': LenraIconBuilder(),
-  };
-
-  static Widget parseJson(Map<String, dynamic> json) {
-    if (json.isEmpty) return appErrorUI;
-
-    String? type = getType(json);
-    if (type == null) {
-      throw "No type in component. It should never happen";
-    }
-    LenraComponentBuilder? builder = getComponentBuilder(type);
-    if (builder == null) throw "Componnent mapping does not handle type $type";
-    Map<Symbol, dynamic> parsedProps = parseProps(json, builder.propsTypes);
-    return builder.build(parsedProps);
-  }
-
-  static String? getType(Map<String, dynamic> json) {
-    return json['type'] as String?;
-  }
-
-  static LenraComponentBuilder? getComponentBuilder(String type) {
-    if (componentsMapping.containsKey(type)) {
-      return componentsMapping[type];
-    }
-
-    return null;
-  }
-
-  static Map<Symbol, dynamic> parseProps(Map<String, dynamic> json, Map<String, Type> propsTypes) {
-    Map<Symbol, dynamic> transformedProps = {};
-
-    json.forEach((key, value) {
-      if (propsTypes.containsKey(key)) {
-        Function? parser = getParser(propsTypes[key]!);
-        if (parser != null) {
-          transformedProps[Symbol(key)] = parser(value);
-        }
-      }
-    });
-
-    return transformedProps;
-  }
-
-  static Function? getParser(Type t) {
-    return ParserExt.typeParsers[t];
   }
 }

--- a/test/components/lenra_actionable_test.dart
+++ b/test/components/lenra_actionable_test.dart
@@ -25,7 +25,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {
@@ -73,7 +76,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {
@@ -115,7 +121,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {
@@ -158,7 +167,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {

--- a/test/components/lenra_button_test.dart
+++ b/test/components/lenra_button_test.dart
@@ -18,7 +18,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {

--- a/test/components/lenra_checkbox_test.dart
+++ b/test/components/lenra_checkbox_test.dart
@@ -17,7 +17,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -50,7 +53,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {

--- a/test/components/lenra_dropdown_test.dart
+++ b/test/components/lenra_dropdown_test.dart
@@ -19,7 +19,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
         ),

--- a/test/components/lenra_icon_test.dart
+++ b/test/components/lenra_icon_test.dart
@@ -16,7 +16,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/components/lenra_image_test.dart
+++ b/test/components/lenra_image_test.dart
@@ -72,7 +72,10 @@ void main() {
               builder: (BuildContext context) {
                 _context = context;
 
-                return LenraWidget();
+                return LenraWidget(
+                  buildErrorPage: (_ctx, _e) => Text("error"),
+                  showSnackBar: (_ctx, _e) => {},
+                );
               },
             ),
           ),
@@ -114,7 +117,10 @@ void main() {
               builder: (BuildContext context) {
                 _context = context;
 
-                return LenraWidget();
+                return LenraWidget(
+                  buildErrorPage: (_ctx, _e) => Text("error"),
+                  showSnackBar: (_ctx, _e) => {},
+                );
               },
             ),
           ),
@@ -158,7 +164,10 @@ void main() {
               builder: (BuildContext context) {
                 _context = context;
 
-                return LenraWidget();
+                return LenraWidget(
+                  buildErrorPage: (_ctx, _e) => Text("error"),
+                  showSnackBar: (_ctx, _e) => {},
+                );
               },
             ),
           ),
@@ -199,7 +208,10 @@ void main() {
               builder: (BuildContext context) {
                 _context = context;
 
-                return LenraWidget();
+                return LenraWidget(
+                  buildErrorPage: (_ctx, _e) => Text("error"),
+                  showSnackBar: (_ctx, _e) => {},
+                );
               },
             ),
           ),

--- a/test/components/lenra_menu_item_test.dart
+++ b/test/components/lenra_menu_item_test.dart
@@ -19,7 +19,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {
@@ -38,10 +41,7 @@ void main() {
           {
             "type": "menuItem",
             "text": "foo",
-            "icon": {
-              "type": "icon",
-              "value": "aod"
-            },
+            "icon": {"type": "icon", "value": "aod"},
             "onPressed": {"code": "yourCode"}
           },
         ],

--- a/test/components/lenra_menu_test.dart
+++ b/test/components/lenra_menu_test.dart
@@ -16,7 +16,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -50,7 +53,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/components/lenra_radio_test.dart
+++ b/test/components/lenra_radio_test.dart
@@ -17,7 +17,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -75,7 +78,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {

--- a/test/components/lenra_slider_test.dart
+++ b/test/components/lenra_slider_test.dart
@@ -17,7 +17,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -66,7 +69,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (Event e) {

--- a/test/components/lenra_stack_test.dart
+++ b/test/components/lenra_stack_test.dart
@@ -16,7 +16,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -51,7 +54,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -85,7 +91,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -118,7 +127,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/components/lenra_text_test.dart
+++ b/test/components/lenra_text_test.dart
@@ -17,7 +17,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/components/lenra_textfield_test.dart
+++ b/test/components/lenra_textfield_test.dart
@@ -19,7 +19,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -59,7 +62,10 @@ void main() {
             builder: (BuildContext context) {
               _context = context;
 
-              return LenraWidget();
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
             },
           ),
           onNotification: (OnChangedEvent e) {

--- a/test/components/lenra_toggle_test.dart
+++ b/test/components/lenra_toggle_test.dart
@@ -18,7 +18,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -67,13 +70,17 @@ void main() {
     await tester.pumpWidget(
       createBaseTestWidgets(
         child: NotificationListener(
-          child:Builder(
-          builder: (BuildContext context) {
-            _context = context;
+          child: Builder(
+            builder: (BuildContext context) {
+              _context = context;
 
-            return LenraWidget();
-          },
-        ),onNotification: (Event e) {
+              return LenraWidget(
+                buildErrorPage: (_ctx, _e) => Text("error"),
+                showSnackBar: (_ctx, _e) => {},
+              );
+            },
+          ),
+          onNotification: (Event e) {
             expect(e.code, "YourCode");
             hasBeenNotified = true;
             return false;

--- a/test/layout/lenra_container_test.dart
+++ b/test/layout/lenra_container_test.dart
@@ -16,7 +16,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -66,7 +69,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -108,7 +114,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/layout/lenra_wrap_test.dart
+++ b/test/layout/lenra_wrap_test.dart
@@ -16,7 +16,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -60,7 +63,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -110,7 +116,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -144,7 +153,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/lenra_button_test.dart
+++ b/test/lenra_button_test.dart
@@ -17,7 +17,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/lenra_ui_builder_test.dart
+++ b/test/lenra_ui_builder_test.dart
@@ -16,7 +16,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -50,7 +53,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -89,7 +95,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -131,7 +140,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),
@@ -170,7 +182,10 @@ void main() {
           builder: (BuildContext context) {
             _context = context;
 
-            return LenraWidget();
+            return LenraWidget(
+              buildErrorPage: (_ctx, _e) => Text("error"),
+              showSnackBar: (_ctx, _e) => {},
+            );
           },
         ),
       ),

--- a/test/test_helper.dart
+++ b/test/test_helper.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 Widget createBaseTestWidgets({required Widget child}) {
   return MultiProvider(
     providers: [
-      ChangeNotifierProvider<WidgetModel>(create: (_) => WidgetModel()),
+      ChangeNotifierProvider<WidgetModel>(create: (_) => WidgetModel<String>()),
       ChangeNotifierProvider<LenraApplicationModel>(
         create: (context) => LenraApplicationModel('foo-url', "appName", ''),
       ),


### PR DESCRIPTION
Add a snack bar for print message error from channel.
If the widgetModel doesn't have ui show error page

Closes https://github.com/lenra-io/client/issues/49