### PR TITLE
feat!: client-app fusion

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,52 @@
+import 'package:lenra_ui_runner/lenra_ui_controller.dart';
+import 'package:lenra_ui_runner/models/channel_model.dart';
+import 'package:lenra_ui_runner/models/client_widget_model.dart';
+import 'package:lenra_ui_runner/models/socket_model.dart';
+import 'package:flutter/material.dart';
+import 'package:lenra_ui_runner/widget_model.dart';
+import 'package:provider/provider.dart';
+
+class App extends StatefulWidget {
+  final String appName;
+
+  const App({Key? key, required this.appName}) : super(key: key);
+
+  @override
+  State<App> createState() {
+    return _AppState();
+  }
+}
+
+class _AppState extends State<App> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProxyProvider<SocketModel, ChannelModel>(
+          create: (context) => ChannelModel(socketModel: context.read<SocketModel>()),
+          update: (_, socketModel, channelModel) {
+            if (channelModel == null) {
+              return ChannelModel(socketModel: socketModel);
+            }
+            return channelModel.update(socketModel);
+          },
+        ),
+        ChangeNotifierProxyProvider<ChannelModel, WidgetModel>(
+          create: (context) => ClientWidgetModel(channelModel: context.read<ChannelModel>()),
+          update: (_, channelModel, clientWidgetModel) => clientWidgetModel!,
+        ),
+      ],
+      builder: (BuildContext context, _) {
+        context.read<ChannelModel>().createChannel(widget.appName);
+        (context.read<WidgetModel>() as ClientWidgetModel).setupListeners();
+
+        return const LenraUiController();
+      },
+    );
+  }
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
 
-class App extends StatefulWidget {
+class App extends StatelessWidget {
   /// The name of the Lenra application.
   final String appName;
 
@@ -21,24 +21,12 @@ class App extends StatefulWidget {
   const App({Key? key, required this.appName, required this.httpEndpoint, required this.accessToken}) : super(key: key);
 
   @override
-  State<App> createState() {
-    return _AppState();
-  }
-}
-
-class _AppState extends State<App> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<UserApplicationModel>(create: (context) => UserApplicationModel()),
         ChangeNotifierProvider<LenraApplicationModel>(
-          create: (context) => LenraApplicationModel(widget.httpEndpoint, widget.appName, widget.accessToken),
+          create: (context) => LenraApplicationModel(httpEndpoint, appName, accessToken),
         ),
         ChangeNotifierProxyProvider<SocketModel, ChannelModel>(
           create: (context) => ChannelModel(socketModel: context.read<SocketModel>()),
@@ -55,7 +43,7 @@ class _AppState extends State<App> {
         ),
       ],
       builder: (BuildContext context, _) {
-        context.read<ChannelModel>().createChannel(widget.appName);
+        context.read<ChannelModel>().createChannel(appName);
         (context.read<WidgetModel>() as ClientWidgetModel).setupListeners();
 
         return const LenraUiController();

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:lenra_ui_runner/widget_model.dart';
 import 'package:provider/provider.dart';
 
 class App extends StatefulWidget {
+  /// The name of the Lenra application.
   final String appName;
 
   /// The URL of the Lenra server.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,5 @@
+import 'package:client_common/models/user_application_model.dart';
+import 'package:lenra_ui_runner/lenra_application_model.dart';
 import 'package:lenra_ui_runner/lenra_ui_controller.dart';
 import 'package:lenra_ui_runner/models/channel_model.dart';
 import 'package:lenra_ui_runner/models/client_widget_model.dart';
@@ -9,7 +11,13 @@ import 'package:provider/provider.dart';
 class App extends StatefulWidget {
   final String appName;
 
-  const App({Key? key, required this.appName}) : super(key: key);
+  /// The URL of the Lenra server.
+  final String httpEndpoint;
+
+  /// The access token to use for the Lenra server.
+  final String accessToken;
+
+  const App({Key? key, required this.appName, required this.httpEndpoint, required this.accessToken}) : super(key: key);
 
   @override
   State<App> createState() {
@@ -27,6 +35,10 @@ class _AppState extends State<App> {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider<UserApplicationModel>(create: (context) => UserApplicationModel()),
+        ChangeNotifierProvider<LenraApplicationModel>(
+          create: (context) => LenraApplicationModel(widget.httpEndpoint, widget.appName, widget.accessToken),
+        ),
         ChangeNotifierProxyProvider<SocketModel, ChannelModel>(
           create: (context) => ChannelModel(socketModel: context.read<SocketModel>()),
           update: (_, socketModel, channelModel) {

--- a/lib/lenra_ui_controller.dart
+++ b/lib/lenra_ui_controller.dart
@@ -1,0 +1,53 @@
+import 'package:lenra_ui_runner/models/channel_model.dart';
+import 'package:client_common/api/response_models/api_errors.dart';
+import 'package:client_common/lenra_application/api_error_snack_bar.dart';
+import 'package:client_common/lenra_application/app_error_page.dart';
+import 'package:client_common/lenra_application/lenra_error_page.dart';
+import 'package:flutter/material.dart';
+import 'package:lenra_ui_runner/components/events/event.dart';
+import 'package:lenra_ui_runner/lenra_ui_runner.dart';
+import 'package:provider/provider.dart';
+
+class LenraUiController extends StatefulWidget {
+  const LenraUiController({Key? key}) : super(key: key);
+
+  @override
+  State<LenraUiController> createState() {
+    return _LenraUiControllerState();
+  }
+}
+
+class _LenraUiControllerState extends State<LenraUiController> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ChannelModel channelModel = context.watch<ChannelModel>();
+    Widget res;
+    if (channelModel.hasError) {
+      res = LenraErrorPage(apiErrors: channelModel.errors!);
+    } else if (!channelModel.isInitialized) {
+      res = const Center(
+        child: CircularProgressIndicator(),
+      );
+    } else {
+      res = LenraWidget<ApiErrors>(
+        buildErrorPage: (BuildContext context, ApiErrors errors) => AppErrorPage(apiErrors: errors),
+        showSnackBar: (BuildContext context, ApiErrors errors) => {
+          ScaffoldMessenger.of(context).showSnackBar(ApiErrorSnackBar(
+            errors: errors,
+            onPressAction: () => ScaffoldMessenger.of(context).clearSnackBars(),
+            actionLabel: "Ok",
+          )),
+        },
+      );
+    }
+    return NotificationListener(
+      onNotification: (Event event) => context.read<ChannelModel>().handleNotifications(event),
+      child: Scaffold(body: res),
+    );
+  }
+}

--- a/lib/lenra_ui_controller.dart
+++ b/lib/lenra_ui_controller.dart
@@ -1,5 +1,5 @@
 import 'package:lenra_ui_runner/models/channel_model.dart';
-import 'package:client_common/api/response_models/api_errors.dart';
+import 'package:client_common/api/response_models/api_error.dart';
 import 'package:client_common/lenra_application/api_error_snack_bar.dart';
 import 'package:client_common/lenra_application/app_error_page.dart';
 import 'package:client_common/lenra_application/lenra_error_page.dart';
@@ -16,17 +16,17 @@ class LenraUiController extends StatelessWidget {
     ChannelModel channelModel = context.watch<ChannelModel>();
     Widget res;
     if (channelModel.hasError) {
-      res = LenraErrorPage(apiErrors: channelModel.errors!);
+      res = LenraErrorPage(apiError: channelModel.error!);
     } else if (!channelModel.isInitialized) {
       res = const Center(
         child: CircularProgressIndicator(),
       );
     } else {
-      res = LenraWidget<ApiErrors>(
-        buildErrorPage: (BuildContext context, ApiErrors errors) => AppErrorPage(apiErrors: errors),
-        showSnackBar: (BuildContext context, ApiErrors errors) => {
+      res = LenraWidget<ApiError>(
+        buildErrorPage: (BuildContext context, ApiError error) => AppErrorPage(apiError: error),
+        showSnackBar: (BuildContext context, ApiError error) => {
           ScaffoldMessenger.of(context).showSnackBar(ApiErrorSnackBar(
-            errors: errors,
+            error: error,
             onPressAction: () => ScaffoldMessenger.of(context).clearSnackBars(),
             actionLabel: "Ok",
           )),

--- a/lib/lenra_ui_controller.dart
+++ b/lib/lenra_ui_controller.dart
@@ -8,20 +8,8 @@ import 'package:lenra_ui_runner/components/events/event.dart';
 import 'package:lenra_ui_runner/lenra_ui_runner.dart';
 import 'package:provider/provider.dart';
 
-class LenraUiController extends StatefulWidget {
+class LenraUiController extends StatelessWidget {
   const LenraUiController({Key? key}) : super(key: key);
-
-  @override
-  State<LenraUiController> createState() {
-    return _LenraUiControllerState();
-  }
-}
-
-class _LenraUiControllerState extends State<LenraUiController> {
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/models/app_socket_model.dart
+++ b/lib/models/app_socket_model.dart
@@ -1,0 +1,39 @@
+import 'package:lenra_ui_runner/models/socket_model.dart';
+import 'package:lenra_ui_runner/socket/lenra_channel.dart';
+import 'package:client_common/config/config.dart';
+import 'package:client_common/utils/connexion_utils_stub.dart'
+    if (dart.library.io) 'package:client_common/utils/connexion_utils_io.dart'
+    if (dart.library.js) 'package:client_common/utils/connexion_utils_web.dart';
+import 'package:phoenix_wings/phoenix_wings.dart';
+
+class AppSocketModel extends SocketModel {
+  String accessToken;
+  PhoenixSocket? _socket;
+
+  AppSocketModel(this.accessToken) {
+    _updateSocket();
+  }
+
+  void _updateSocket() {
+    _socket?.disconnect();
+
+    _socket = createPhoenixSocket(
+      Config.instance.wsEndpoint,
+      {"token": accessToken},
+    );
+    _socket?.connect();
+  }
+
+  void update(String accessToken) {
+    this.accessToken = accessToken;
+    _updateSocket();
+    notifyListeners();
+  }
+
+  @override
+  LenraChannel channel(String channelName, Map<String, dynamic> params) {
+    if (_socket == null) throw "Socket must not be null";
+
+    return LenraChannel(_socket!, channelName, params);
+  }
+}

--- a/lib/models/channel_model.dart
+++ b/lib/models/channel_model.dart
@@ -1,0 +1,50 @@
+import 'package:lenra_ui_runner/models/socket_model.dart';
+import 'package:lenra_ui_runner/socket/lenra_channel.dart';
+import 'package:client_common/api/response_models/api_errors.dart';
+import 'package:flutter/widgets.dart';
+import 'package:lenra_ui_runner/components/events/event.dart';
+
+class ChannelModel extends ChangeNotifier {
+  LenraChannel? channel;
+  bool hasError = false;
+  bool _isInitialized = false;
+  ApiErrors? errors;
+  late SocketModel socketModel;
+
+  ChannelModel({required this.socketModel});
+
+  bool get isInitialized {
+    return _isInitialized;
+  }
+
+  set isInitialized(bool value) {
+    _isInitialized = value;
+    notifyListeners();
+  }
+
+  void createChannel(String appName) {
+    channel = socketModel.channel("app", {"app": appName});
+
+    channel!.onError((response) {
+      hasError = true;
+      isInitialized = true;
+      errors = ApiErrors.fromJson(response!["reason"]);
+      notifyListeners();
+    });
+  }
+
+  ChannelModel update(SocketModel socketModel) {
+    this.socketModel = socketModel;
+
+    return this;
+  }
+
+  bool handleNotifications(Event notification) {
+    channel!.send('run', notification.toMap());
+    return true;
+  }
+
+  void close() {
+    channel!.close();
+  }
+}

--- a/lib/models/channel_model.dart
+++ b/lib/models/channel_model.dart
@@ -1,6 +1,6 @@
 import 'package:lenra_ui_runner/models/socket_model.dart';
 import 'package:lenra_ui_runner/socket/lenra_channel.dart';
-import 'package:client_common/api/response_models/api_errors.dart';
+import 'package:client_common/api/response_models/api_error.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lenra_ui_runner/components/events/event.dart';
 
@@ -8,7 +8,7 @@ class ChannelModel extends ChangeNotifier {
   LenraChannel? channel;
   bool hasError = false;
   bool _isInitialized = false;
-  ApiErrors? errors;
+  ApiError? error;
   late SocketModel socketModel;
 
   ChannelModel({required this.socketModel});
@@ -28,7 +28,7 @@ class ChannelModel extends ChangeNotifier {
     channel!.onError((response) {
       hasError = true;
       isInitialized = true;
-      errors = ApiErrors.fromJson(response!["reason"]);
+      error = ApiError.fromJson(response!["reason"]);
       notifyListeners();
     });
   }

--- a/lib/models/client_widget_model.dart
+++ b/lib/models/client_widget_model.dart
@@ -1,8 +1,8 @@
 import 'package:lenra_ui_runner/models/channel_model.dart';
-import 'package:client_common/api/response_models/api_errors.dart';
+import 'package:client_common/api/response_models/api_error.dart';
 import 'package:lenra_ui_runner/widget_model.dart';
 
-class ClientWidgetModel extends WidgetModel<ApiErrors> {
+class ClientWidgetModel extends WidgetModel<ApiError> {
   late ChannelModel channelModel;
 
   ClientWidgetModel({required this.channelModel});
@@ -28,7 +28,7 @@ class ClientWidgetModel extends WidgetModel<ApiErrors> {
         channelModel.isInitialized = true;
       }
 
-      setErrors(ApiErrors.fromJson(json["errors"]));
+      setErrors(ApiError.fromJson(json["errors"]));
     });
   }
 }

--- a/lib/models/client_widget_model.dart
+++ b/lib/models/client_widget_model.dart
@@ -1,0 +1,34 @@
+import 'package:lenra_ui_runner/models/channel_model.dart';
+import 'package:client_common/api/response_models/api_errors.dart';
+import 'package:lenra_ui_runner/widget_model.dart';
+
+class ClientWidgetModel extends WidgetModel<ApiErrors> {
+  late ChannelModel channelModel;
+
+  ClientWidgetModel({required this.channelModel});
+
+  void setupListeners() {
+    channelModel.channel!.onUi((Map<dynamic, dynamic>? ui) {
+      if (ui == null) return;
+
+      if (!channelModel.isInitialized) {
+        channelModel.isInitialized = true;
+      }
+
+      replaceUi(ui as Map<String, dynamic>);
+    });
+
+    channelModel.channel!.onPatchUi((Map<dynamic, dynamic>? json) {
+      Iterable<Map<String, dynamic>> patches = (json?["patch"] as Iterable).map((e) => e as Map<String, dynamic>);
+      patchUi(patches);
+    });
+
+    channelModel.channel!.onAppError((Map<dynamic, dynamic> json) {
+      if (!channelModel.isInitialized) {
+        channelModel.isInitialized = true;
+      }
+
+      setErrors(ApiErrors.fromJson(json["errors"]));
+    });
+  }
+}

--- a/lib/models/socket_model.dart
+++ b/lib/models/socket_model.dart
@@ -1,0 +1,6 @@
+import 'package:lenra_ui_runner/socket/lenra_channel.dart';
+import 'package:flutter/widgets.dart';
+
+abstract class SocketModel extends ChangeNotifier {
+  LenraChannel channel(String channelName, Map<String, dynamic> params);
+}

--- a/lib/socket/lenra_channel.dart
+++ b/lib/socket/lenra_channel.dart
@@ -1,0 +1,52 @@
+library socket;
+
+import 'package:phoenix_wings/phoenix_wings.dart';
+
+class LenraChannel {
+  late PhoenixChannel _channel;
+  final List<dynamic Function(Map<dynamic, dynamic>?)> _errorCallbacks = [];
+  LenraChannel(PhoenixSocket socket, String channelName, Map<String, dynamic> params) {
+    _channel = socket.channel(channelName, params);
+    _channel.join()?.receive("error", (Map<dynamic, dynamic>? response) {
+      for (var c in _errorCallbacks) {
+        c(response);
+      }
+    });
+  }
+
+  void close() {
+    _channel.off("ui");
+    _channel.off("patchUi");
+    _channel.off("error");
+    _channel.leave();
+  }
+
+  void onUi(void Function(Map<dynamic, dynamic>) callback) {
+    _channel.on("ui", (payload, ref, joinRef) {
+      if (payload == null) return;
+      callback(payload);
+    });
+  }
+
+  void onPatchUi(void Function(Map<dynamic, dynamic>) callback) {
+    _channel.on("patchUi", (payload, ref, joinRef) {
+      if (payload == null) return;
+      callback(payload);
+    });
+  }
+
+  void onAppError(void Function(Map<dynamic, dynamic>) callback) {
+    _channel.on("error", (payload, ref, joinRef) {
+      if (payload == null) return;
+      callback(payload);
+    });
+  }
+
+  void onError(dynamic Function(Map<dynamic, dynamic>?) callback) {
+    _errorCallbacks.add(callback);
+  }
+
+  void send(String event, dynamic data) {
+    _channel.push(event: event, payload: data as Map<dynamic, dynamic>);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -124,8 +124,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.0.0-beta.2"
-      resolved-ref: "441f098595674c8bb6d27b8f525a0f77d8d83f2b"
+      ref: "v1.0.0-beta.7"
+      resolved-ref: e5406739f4746d13e363dfd34d5e87d9f8534dc7
       url: "git@github.com:lenra-io/client-common.git"
     source: git
     version: "1.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -120,6 +120,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.5"
+  client_common:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: "v1.0.0-beta.2"
+      resolved-ref: "441f098595674c8bb6d27b8f525a0f77d8d83f2b"
+      url: "git@github.com:lenra-io/client-common.git"
+    source: git
+    version: "1.0.0"
   clock:
     dependency: transitive
     description:
@@ -155,6 +164,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.2"
   dart_style:
     dependency: transitive
     description:
@@ -188,6 +204,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown:
+    dependency: transitive
+    description:
+      name: flutter_markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.10+2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -214,6 +237,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:
@@ -279,6 +316,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -335,6 +379,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  phoenix_wings:
+    dependency: "direct main"
+    description:
+      name: phoenix_wings
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   pool:
     dependency: transitive
     description:
@@ -452,6 +503,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_html:
+    dependency: transitive
+    description:
+      name: universal_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:
@@ -481,5 +546,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.17.1 <3.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   client_common:
     git:
       url: git@github.com:lenra-io/client-common.git
-      ref: v1.0.0-beta.2
+      ref: v1.0.0-beta.7
   json_patch: ^3.0.0
   mockito: ^5.0.17
   phoenix_wings: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   client_common:
     git:
       url: git@github.com:lenra-io/client-common.git
-      ref: v1.0.0-beta.7
+      ref: v1.0.0-beta.8
   json_patch: ^3.0.0
   mockito: ^5.0.17
   phoenix_wings: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,13 @@ dependencies:
     git:
       url: git@github.com:lenra-io/lenra_components.git
       ref: v1.0.0-beta.45
+  client_common:
+    git:
+      url: git@github.com:lenra-io/client-common.git
+      ref: v1.0.0-beta.2
   json_patch: ^3.0.0
   mockito: ^5.0.17
+  phoenix_wings: ^1.0.2
 dev_dependencies:
   build_runner: ^2.1.7
   flutter_test:

--- a/test/lenra_ui_controller_test.dart
+++ b/test/lenra_ui_controller_test.dart
@@ -16,6 +16,8 @@ void main() {
             create: (context) => AppSocketModel("random-access-token"),
             child: const App(
               appName: "app-name",
+              httpEndpoint: "http://localhost:4000",
+              accessToken: "random-access-token",
             ),
           ),
         ),

--- a/test/lenra_ui_controller_test.dart
+++ b/test/lenra_ui_controller_test.dart
@@ -1,0 +1,58 @@
+import 'package:lenra_ui_runner/app.dart';
+import 'package:lenra_ui_runner/lenra_ui_controller.dart';
+import 'package:lenra_ui_runner/models/app_socket_model.dart';
+import 'package:lenra_ui_runner/models/socket_model.dart';
+import 'package:client_common/test/lenra_page_test_help.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  testWidgets('LenraUiController simple instantiation', (WidgetTester tester) async {
+    await tester.runAsync(
+      () => tester.pumpWidget(
+        createAppTestWidgets(
+          ChangeNotifierProvider<SocketModel>(
+            create: (context) => AppSocketModel("random-access-token"),
+            child: const App(
+              appName: "app-name",
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(LenraUiController), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  // TODO : Fix this test to make sure that the lenra_ui_controller widget is working
+  // testWidgets('LenraUiController with initialized ChannelModel',
+  //     (WidgetTester tester) async {
+  //   final GlobalKey key = GlobalKey();
+
+  //   await tester.runAsync(
+  //     () => tester.pumpWidget(
+  //       createAppTestWidgets(
+  //         LenraUiController(
+  //           key: key,
+  //           accessToken: "random-access-token",
+  //           appName: "app-name",
+  //         ),
+  //       ),
+  //     ),
+  //   );
+
+  //   await tester.pump();
+
+  //   final context = tester.element(find.byType(Scaffold));
+  //   context.read<ChannelModel>().channel!.send("ui", {"data": "data"});
+
+  //   await tester.pump();
+
+  //   expect(find.byType(LenraUiController), findsOneWidget);
+  //   // expect(find.byType(LenraErrorPage), findsOneWidget);
+  //   // expect(find.byType(LenraWidget<ApiErrors>), findsOneWidget);
+  //   expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  // });
+}


### PR DESCRIPTION
<!-- 
Link the related issue :
#42
-->
Linked to #160

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

This work is made to get rid of the client-app repository which is not really useful as an independant repository in its current state.
Files that were moved from client-app to this PR:
- app.dart (to instantiate an app in any Flutter app)
- lenra_ui_controller.dart (to take care of LenraWidget instantiation & other)
- app_socket_model.dart
- channel_model.dart
- client_widget_model.dart
- socket_model.dart
- lenra_channel.dart

Some changes were also made on the `app.dart` file to make it easier for the developer to use the library. There is no need to instantiate the Provider LenraApplicationModel anymore because its parameters are now passed directly to the App widget (appName, httpEndpoint, accessToken). The App widget takes care of creating the LenraApplicationModel for you with these parameters.
 
