### PR TITLE
feat: Add more examples to dropdown

### DIFF
--- a/examples/showcase/lib/pages/lenra_dropdown_button.dart
+++ b/examples/showcase/lib/pages/lenra_dropdown_button.dart
@@ -26,6 +26,47 @@ class _LenraDropdownButtonPageState extends UiBuilderState<LenraDropdownButtonPa
               "onPressed": {"code": "myCode"},
             },
           },
+          {
+            "_type": "dropdownButton",
+            "text": "multiple children",
+            "child": {
+              "_type": "flex",
+              "direction": "vertical",
+              "children": [
+                {
+                  "_type": "button",
+                  "text": "foo",
+                  "mainStyle": "secondary",
+                  "onPressed": {"code": "myCode"},
+                },
+                {
+                  "_type": "button",
+                  "text": "bar",
+                  "mainStyle": "secondary",
+                  "onPressed": {"code": "myCode"},
+                },
+              ],
+            }
+          },
+          {
+            "_type": "dropdownButton",
+            "text": "Menu child",
+            "child": {
+              "_type": "menu",
+              "children": [
+                {
+                  "_type": "menuItem",
+                  "text": "foo",
+                  "onPressed": {"code": "myCode"},
+                },
+                {
+                  "_type": "menuItem",
+                  "text": "bar",
+                  "onPressed": {"code": "myCode"},
+                },
+              ],
+            }
+          },
           {"_type": "text", "value": "$data"},
           {
             "_type": "dropdownButton",


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Closes # 
<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->

I added more examples to the dropdown button component to check for a bug that was found on an application caused by the buttons inside of the dropdown that are not triggering their listeners and causing an error instead.

It seems that the bug is not coming from here but I'm still adding these examples as they are nice to have.


## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


